### PR TITLE
Update to latest changes from 2019-06-20

### DIFF
--- a/docs/ActionApi.md
+++ b/docs/ActionApi.md
@@ -1,10 +1,11 @@
 # ApprovalApiClient::ActionApi
 
-All URIs are relative to *http://localhost/api/approval/v1.0*
+All URIs are relative to *https://cloud.redhat.com//api/approval/v1.0*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
 [**create_action**](ActionApi.md#create_action) | **POST** /stages/{stage_id}/actions | Add an action to a given stage
+[**create_action_by_request**](ActionApi.md#create_action_by_request) | **POST** /requests/{request_id}/actions | Add an action to current active stage of a given request
 [**list_actions_by_stage**](ActionApi.md#list_actions_by_stage) | **GET** /stages/{stage_id}/actions | Return actions in a given stage
 [**show_action**](ActionApi.md#show_action) | **GET** /actions/{id} | Return an user action by id
 
@@ -28,7 +29,7 @@ ApprovalApiClient.configure do |config|
 end
 
 api_instance = ApprovalApiClient::ActionApi.new
-stage_id = 56 # Integer | Id of stage
+stage_id = 'stage_id_example' # String | Id of stage
 action_in = ApprovalApiClient::ActionIn.new # ActionIn | Action object that will be added
 
 begin
@@ -44,7 +45,60 @@ end
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **stage_id** | **Integer**| Id of stage | 
+ **stage_id** | **String**| Id of stage | 
+ **action_in** | [**ActionIn**](ActionIn.md)| Action object that will be added | 
+
+### Return type
+
+[**ActionOut**](ActionOut.md)
+
+### Authorization
+
+[Basic_auth](../README.md#Basic_auth)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
+
+
+
+# **create_action_by_request**
+> ActionOut create_action_by_request(request_id, action_in)
+
+Add an action to current active stage of a given request
+
+Add an action to current active stage of a given request. If request is finished, i.e. no current active stage is available, no action can be posted here.
+
+### Example
+```ruby
+# load the gem
+require 'approval-api-client-ruby'
+# setup authorization
+ApprovalApiClient.configure do |config|
+  # Configure HTTP basic authorization: Basic_auth
+  config.username = 'YOUR USERNAME'
+  config.password = 'YOUR PASSWORD'
+end
+
+api_instance = ApprovalApiClient::ActionApi.new
+request_id = 'request_id_example' # String | Id of request
+action_in = ApprovalApiClient::ActionIn.new # ActionIn | Action object that will be added
+
+begin
+  #Add an action to current active stage of a given request
+  result = api_instance.create_action_by_request(request_id, action_in)
+  p result
+rescue ApprovalApiClient::ApiError => e
+  puts "Exception when calling ActionApi->create_action_by_request: #{e}"
+end
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **request_id** | **String**| Id of request | 
  **action_in** | [**ActionIn**](ActionIn.md)| Action object that will be added | 
 
 ### Return type
@@ -81,7 +135,7 @@ ApprovalApiClient.configure do |config|
 end
 
 api_instance = ApprovalApiClient::ActionApi.new
-stage_id = 56 # Integer | Id of stage
+stage_id = 'stage_id_example' # String | Id of stage
 
 begin
   #Return actions in a given stage
@@ -96,7 +150,7 @@ end
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **stage_id** | **Integer**| Id of stage | 
+ **stage_id** | **String**| Id of stage | 
 
 ### Return type
 
@@ -132,7 +186,7 @@ ApprovalApiClient.configure do |config|
 end
 
 api_instance = ApprovalApiClient::ActionApi.new
-id = 56 # Integer | Query by id
+id = 'id_example' # String | Query by id
 
 begin
   #Return an user action by id
@@ -147,7 +201,7 @@ end
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **id** | **Integer**| Query by id | 
+ **id** | **String**| Query by id | 
 
 ### Return type
 

--- a/docs/ActionIn.md
+++ b/docs/ActionIn.md
@@ -4,7 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **processed_by** | **String** | The person who performs the action | [optional] 
-**operation** | **String** | Types of action, may be one of the value (approve, deny, notify, memo, or skip). The stage will be updated according to the operation. | [default to &#39;memo&#39;]
+**operation** | **String** | Types of action, may be one of the value (approve, cancel, deny, notify, memo, or skip). The stage will be updated according to the operation. | [default to &#39;memo&#39;]
 **comments** | **String** | Comments for action | [optional] 
 
 

--- a/docs/ActionOut.md
+++ b/docs/ActionOut.md
@@ -3,11 +3,11 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**processed_by** | **String** | The person who performs the action | [optional] 
-**operation** | **String** | Types of action, may be one of the value (approve, deny, notify, memo, or skip). The stage will be updated according to the operation. | [default to &#39;memo&#39;]
-**comments** | **String** | Comments for action | [optional] 
 **id** | **String** |  | 
 **created_at** | **DateTime** | Timestamp of creation | [optional] 
 **stage_id** | **String** | Associated stage id | 
+**processed_by** | **String** | The person who performs the action | [optional] 
+**operation** | **String** | Types of action, may be one of the value (approve, cancel, deny, notify, memo, or skip). The stage will be updated according to the operation. | [optional] [default to &#39;memo&#39;]
+**comments** | **String** | Comments for action | [optional] 
 
 

--- a/docs/RequestApi.md
+++ b/docs/RequestApi.md
@@ -1,6 +1,6 @@
 # ApprovalApiClient::RequestApi
 
-All URIs are relative to *http://localhost/api/approval/v1.0*
+All URIs are relative to *https://cloud.redhat.com//api/approval/v1.0*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
@@ -29,7 +29,7 @@ ApprovalApiClient.configure do |config|
 end
 
 api_instance = ApprovalApiClient::RequestApi.new
-workflow_id = 56 # Integer | Id of workflow
+workflow_id = 'workflow_id_example' # String | Id of workflow
 request_in = ApprovalApiClient::RequestIn.new # RequestIn | Parameters need to create a request
 
 begin
@@ -45,7 +45,7 @@ end
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **workflow_id** | **Integer**| Id of workflow | 
+ **workflow_id** | **String**| Id of workflow | 
  **request_in** | [**RequestIn**](RequestIn.md)| Parameters need to create a request | 
 
 ### Return type
@@ -83,11 +83,10 @@ end
 
 api_instance = ApprovalApiClient::RequestApi.new
 opts = {
-  decision: ['decision_example'], # Array<String> | Fetch item by given decision (undecided, approved, denied)
-  state: ['state_example'], # Array<String> | Fetch item by given state (pending, skipped, notified, finished)
-  requester: 'requester_example', # String | Fetch item by given requester
-  limit: 20, # Integer | How many items to return at one time (max 1000)
-  offset: 0 # Integer | Starting Offset
+  approver: 'approver_example', # String | Fetch requests by given approver username
+  limit: 100, # Integer | How many items to return at one time (max 1000)
+  offset: 0, # Integer | Starting Offset
+  filter: nil # Object | Filter for querying collections.
 }
 
 begin
@@ -103,11 +102,10 @@ end
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **decision** | [**Array&lt;String&gt;**](String.md)| Fetch item by given decision (undecided, approved, denied) | [optional] 
- **state** | [**Array&lt;String&gt;**](String.md)| Fetch item by given state (pending, skipped, notified, finished) | [optional] 
- **requester** | **String**| Fetch item by given requester | [optional] 
- **limit** | **Integer**| How many items to return at one time (max 1000) | [optional] [default to 20]
+ **approver** | **String**| Fetch requests by given approver username | [optional] 
+ **limit** | **Integer**| How many items to return at one time (max 1000) | [optional] [default to 100]
  **offset** | **Integer**| Starting Offset | [optional] [default to 0]
+ **filter** | [**Object**](.md)| Filter for querying collections. | [optional] 
 
 ### Return type
 
@@ -143,10 +141,11 @@ ApprovalApiClient.configure do |config|
 end
 
 api_instance = ApprovalApiClient::RequestApi.new
-workflow_id = 56 # Integer | Id of workflow
+workflow_id = 'workflow_id_example' # String | Id of workflow
 opts = {
-  limit: 20, # Integer | How many items to return at one time (max 1000)
-  offset: 0 # Integer | Starting Offset
+  limit: 100, # Integer | How many items to return at one time (max 1000)
+  offset: 0, # Integer | Starting Offset
+  filter: nil # Object | Filter for querying collections.
 }
 
 begin
@@ -162,9 +161,10 @@ end
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **workflow_id** | **Integer**| Id of workflow | 
- **limit** | **Integer**| How many items to return at one time (max 1000) | [optional] [default to 20]
+ **workflow_id** | **String**| Id of workflow | 
+ **limit** | **Integer**| How many items to return at one time (max 1000) | [optional] [default to 100]
  **offset** | **Integer**| Starting Offset | [optional] [default to 0]
+ **filter** | [**Object**](.md)| Filter for querying collections. | [optional] 
 
 ### Return type
 
@@ -200,7 +200,7 @@ ApprovalApiClient.configure do |config|
 end
 
 api_instance = ApprovalApiClient::RequestApi.new
-id = 56 # Integer | Query by id
+id = 'id_example' # String | Query by id
 
 begin
   #Return an approval request by given id
@@ -215,7 +215,7 @@ end
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **id** | **Integer**| Query by id | 
+ **id** | **String**| Query by id | 
 
 ### Return type
 

--- a/docs/RequestOut.md
+++ b/docs/RequestOut.md
@@ -3,14 +3,18 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**requester** | **String** | Requester id | [optional] 
-**name** | **String** | Request name | 
-**description** | **String** | Request description | [optional] 
-**content** | [**Object**](.md) | JSON object with request content | 
 **id** | **String** |  | [optional] 
-**state** | **String** | The state of stage or request. It may be one of values (pending, skipped, notified or finished) | [optional] [default to &#39;pending&#39;]
-**decision** | **String** | Final decision, may be one of the value (undecided, approved, or denied) | [optional] [default to &#39;undecided&#39;]
+**state** | **String** | The state of stage or request. It may be one of values (canceled, pending, skipped, notified or finished) | [optional] [default to &#39;pending&#39;]
+**decision** | **String** | Final decision, may be one of the value (undecided, approved, canceled or denied) | [optional] [default to &#39;undecided&#39;]
 **reason** | **String** | Comments for requests | [optional] 
 **workflow_id** | **String** | Associate workflow id | [optional] 
+**created_at** | **DateTime** | Timestamp of creation | [optional] 
+**updated_at** | **DateTime** | Timestamp of last update | [optional] 
+**active_stage** | **Integer** | Current (or last) active stage. For regular approver this number is always 0 | [optional] 
+**total_stages** | **Integer** | Total number of stages. For regular approver this number is always 0. | [optional] 
+**requester** | **String** | Requester id | [optional] 
+**name** | **String** | Request name | [optional] 
+**description** | **String** | Request description | [optional] 
+**content** | [**Object**](.md) | JSON object with request content | [optional] 
 
 

--- a/docs/StageApi.md
+++ b/docs/StageApi.md
@@ -1,6 +1,6 @@
 # ApprovalApiClient::StageApi
 
-All URIs are relative to *http://localhost/api/approval/v1.0*
+All URIs are relative to *https://cloud.redhat.com//api/approval/v1.0*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
@@ -27,7 +27,7 @@ ApprovalApiClient.configure do |config|
 end
 
 api_instance = ApprovalApiClient::StageApi.new
-request_id = 56 # Integer | Id of request
+request_id = 'request_id_example' # String | Id of request
 
 begin
   #Return an array of stages by given request id
@@ -42,7 +42,7 @@ end
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **request_id** | **Integer**| Id of request | 
+ **request_id** | **String**| Id of request | 
 
 ### Return type
 
@@ -78,7 +78,7 @@ ApprovalApiClient.configure do |config|
 end
 
 api_instance = ApprovalApiClient::StageApi.new
-id = 56 # Integer | Query by id
+id = 'id_example' # String | Query by id
 
 begin
   #Return an approval stage by given id
@@ -93,7 +93,7 @@ end
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **id** | **Integer**| Query by id | 
+ **id** | **String**| Query by id | 
 
 ### Return type
 

--- a/docs/StageOut.md
+++ b/docs/StageOut.md
@@ -6,8 +6,8 @@ Name | Type | Description | Notes
 **id** | **String** |  | [optional] 
 **name** | **String** | name of the group that processes the stage | [optional] 
 **group_ref** | **String** | Associated group reference id | [optional] 
-**state** | **String** | The state of stage or request. It may be one of values (pending, skipped, notified or finished) | [optional] [default to &#39;pending&#39;]
-**decision** | **String** | Final decision, may be one of the value (undecided, approved, or denied) | [optional] [default to &#39;undecided&#39;]
+**state** | **String** | The state of stage or request. It may be one of values (canceled, pending, skipped, notified or finished) | [optional] [default to &#39;pending&#39;]
+**decision** | **String** | Final decision, may be one of the value (undecided, approved, canceled or denied) | [optional] [default to &#39;undecided&#39;]
 **notified_at** | **String** | the time approvers in the stage are notified | [optional] 
 
 

--- a/docs/TemplateApi.md
+++ b/docs/TemplateApi.md
@@ -1,6 +1,6 @@
 # ApprovalApiClient::TemplateApi
 
-All URIs are relative to *http://localhost/api/approval/v1.0*
+All URIs are relative to *https://cloud.redhat.com//api/approval/v1.0*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
@@ -28,8 +28,9 @@ end
 
 api_instance = ApprovalApiClient::TemplateApi.new
 opts = {
-  limit: 20, # Integer | How many items to return at one time (max 1000)
-  offset: 0 # Integer | Starting Offset
+  limit: 100, # Integer | How many items to return at one time (max 1000)
+  offset: 0, # Integer | Starting Offset
+  filter: nil # Object | Filter for querying collections.
 }
 
 begin
@@ -45,8 +46,9 @@ end
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **limit** | **Integer**| How many items to return at one time (max 1000) | [optional] [default to 20]
+ **limit** | **Integer**| How many items to return at one time (max 1000) | [optional] [default to 100]
  **offset** | **Integer**| Starting Offset | [optional] [default to 0]
+ **filter** | [**Object**](.md)| Filter for querying collections. | [optional] 
 
 ### Return type
 
@@ -82,7 +84,7 @@ ApprovalApiClient.configure do |config|
 end
 
 api_instance = ApprovalApiClient::TemplateApi.new
-id = 56 # Integer | Query by id
+id = 'id_example' # String | Query by id
 
 begin
   #Return a template by given id
@@ -97,7 +99,7 @@ end
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **id** | **Integer**| Query by id | 
+ **id** | **String**| Query by id | 
 
 ### Return type
 

--- a/docs/WorkflowApi.md
+++ b/docs/WorkflowApi.md
@@ -1,6 +1,6 @@
 # ApprovalApiClient::WorkflowApi
 
-All URIs are relative to *http://localhost/api/approval/v1.0*
+All URIs are relative to *https://cloud.redhat.com//api/approval/v1.0*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
@@ -31,7 +31,7 @@ ApprovalApiClient.configure do |config|
 end
 
 api_instance = ApprovalApiClient::WorkflowApi.new
-template_id = 56 # Integer | Id of template
+template_id = 'template_id_example' # String | Id of template
 workflow_in = ApprovalApiClient::WorkflowIn.new # WorkflowIn | Parameters need to create workflow
 
 begin
@@ -47,7 +47,7 @@ end
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **template_id** | **Integer**| Id of template | 
+ **template_id** | **String**| Id of template | 
  **workflow_in** | [**WorkflowIn**](WorkflowIn.md)| Parameters need to create workflow | 
 
 ### Return type
@@ -84,7 +84,7 @@ ApprovalApiClient.configure do |config|
 end
 
 api_instance = ApprovalApiClient::WorkflowApi.new
-id = 56 # Integer | Query by id
+id = 'id_example' # String | Query by id
 
 begin
   #Delete approval workflow by given id
@@ -98,7 +98,7 @@ end
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **id** | **Integer**| Query by id | 
+ **id** | **String**| Query by id | 
 
 ### Return type
 
@@ -135,8 +135,9 @@ end
 
 api_instance = ApprovalApiClient::WorkflowApi.new
 opts = {
-  limit: 20, # Integer | How many items to return at one time (max 1000)
-  offset: 0 # Integer | Starting Offset
+  limit: 100, # Integer | How many items to return at one time (max 1000)
+  offset: 0, # Integer | Starting Offset
+  filter: nil # Object | Filter for querying collections.
 }
 
 begin
@@ -152,8 +153,9 @@ end
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **limit** | **Integer**| How many items to return at one time (max 1000) | [optional] [default to 20]
+ **limit** | **Integer**| How many items to return at one time (max 1000) | [optional] [default to 100]
  **offset** | **Integer**| Starting Offset | [optional] [default to 0]
+ **filter** | [**Object**](.md)| Filter for querying collections. | [optional] 
 
 ### Return type
 
@@ -189,10 +191,11 @@ ApprovalApiClient.configure do |config|
 end
 
 api_instance = ApprovalApiClient::WorkflowApi.new
-template_id = 56 # Integer | Id of template
+template_id = 'template_id_example' # String | Id of template
 opts = {
-  limit: 20, # Integer | How many items to return at one time (max 1000)
-  offset: 0 # Integer | Starting Offset
+  limit: 100, # Integer | How many items to return at one time (max 1000)
+  offset: 0, # Integer | Starting Offset
+  filter: nil # Object | Filter for querying collections.
 }
 
 begin
@@ -208,9 +211,10 @@ end
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **template_id** | **Integer**| Id of template | 
- **limit** | **Integer**| How many items to return at one time (max 1000) | [optional] [default to 20]
+ **template_id** | **String**| Id of template | 
+ **limit** | **Integer**| How many items to return at one time (max 1000) | [optional] [default to 100]
  **offset** | **Integer**| Starting Offset | [optional] [default to 0]
+ **filter** | [**Object**](.md)| Filter for querying collections. | [optional] 
 
 ### Return type
 
@@ -246,7 +250,7 @@ ApprovalApiClient.configure do |config|
 end
 
 api_instance = ApprovalApiClient::WorkflowApi.new
-id = 56 # Integer | Query by id
+id = 'id_example' # String | Query by id
 
 begin
   #Return an approval workflow by given id
@@ -261,7 +265,7 @@ end
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **id** | **Integer**| Query by id | 
+ **id** | **String**| Query by id | 
 
 ### Return type
 
@@ -297,7 +301,7 @@ ApprovalApiClient.configure do |config|
 end
 
 api_instance = ApprovalApiClient::WorkflowApi.new
-id = 56 # Integer | Query by id
+id = 'id_example' # String | Query by id
 workflow_in = ApprovalApiClient::WorkflowIn.new # WorkflowIn | Parameters need to update approval workflow
 
 begin
@@ -313,7 +317,7 @@ end
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **id** | **Integer**| Query by id | 
+ **id** | **String**| Query by id | 
  **workflow_in** | [**WorkflowIn**](WorkflowIn.md)| Parameters need to update approval workflow | 
 
 ### Return type

--- a/docs/WorkflowOut.md
+++ b/docs/WorkflowOut.md
@@ -3,10 +3,10 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**name** | **String** |  | 
-**description** | **String** |  | [optional] 
-**group_refs** | **Array&lt;String&gt;** | Group reference ids associated with workflow | 
 **id** | **String** |  | [optional] 
 **template_id** | **String** | Associated template id | [optional] 
+**name** | **String** |  | [optional] 
+**description** | **String** |  | [optional] 
+**group_refs** | **Array&lt;String&gt;** | Group reference ids associated with workflow | [optional] 
 
 

--- a/lib/approval-api-client-ruby/api/action_api.rb
+++ b/lib/approval-api-client-ruby/api/action_api.rb
@@ -80,6 +80,67 @@ module ApprovalApiClient
       return data, status_code, headers
     end
 
+    # Add an action to current active stage of a given request
+    # Add an action to current active stage of a given request. If request is finished, i.e. no current active stage is available, no action can be posted here.
+    # @param request_id Id of request
+    # @param action_in Action object that will be added
+    # @param [Hash] opts the optional parameters
+    # @return [ActionOut]
+    def create_action_by_request(request_id, action_in, opts = {})
+      data, _status_code, _headers = create_action_by_request_with_http_info(request_id, action_in, opts)
+      data
+    end
+
+    # Add an action to current active stage of a given request
+    # Add an action to current active stage of a given request. If request is finished, i.e. no current active stage is available, no action can be posted here.
+    # @param request_id Id of request
+    # @param action_in Action object that will be added
+    # @param [Hash] opts the optional parameters
+    # @return [Array<(ActionOut, Fixnum, Hash)>] ActionOut data, response status code and response headers
+    def create_action_by_request_with_http_info(request_id, action_in, opts = {})
+      if @api_client.config.debugging
+        @api_client.config.logger.debug 'Calling API: ActionApi.create_action_by_request ...'
+      end
+      # verify the required parameter 'request_id' is set
+      if @api_client.config.client_side_validation && request_id.nil?
+        fail ArgumentError, "Missing the required parameter 'request_id' when calling ActionApi.create_action_by_request"
+      end
+      # verify the required parameter 'action_in' is set
+      if @api_client.config.client_side_validation && action_in.nil?
+        fail ArgumentError, "Missing the required parameter 'action_in' when calling ActionApi.create_action_by_request"
+      end
+      # resource path
+      local_var_path = '/requests/{request_id}/actions'.sub('{' + 'request_id' + '}', request_id.to_s)
+
+      # query parameters
+      query_params = {}
+
+      # header parameters
+      header_params = {}
+      # HTTP header 'Accept' (if needed)
+      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      # HTTP header 'Content-Type'
+      header_params['Content-Type'] = @api_client.select_header_content_type(['application/json'])
+
+      # form parameters
+      form_params = {}
+
+      # http body (model)
+      post_body = @api_client.object_to_http_body(action_in)
+      auth_names = ['Basic_auth']
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path,
+        :header_params => header_params,
+        :query_params => query_params,
+        :form_params => form_params,
+        :body => post_body,
+        :auth_names => auth_names,
+        :return_type => 'ActionOut')
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: ActionApi#create_action_by_request\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      end
+      return data, status_code, headers
+    end
+
     # Return actions in a given stage
     # List all actions of a stage
     # @param stage_id Id of stage

--- a/lib/approval-api-client-ruby/api/request_api.rb
+++ b/lib/approval-api-client-ruby/api/request_api.rb
@@ -83,11 +83,10 @@ module ApprovalApiClient
     # Return an array of approval requests
     # Return an array of requests
     # @param [Hash] opts the optional parameters
-    # @option opts [Array<String>] :decision Fetch item by given decision (undecided, approved, denied)
-    # @option opts [Array<String>] :state Fetch item by given state (pending, skipped, notified, finished)
-    # @option opts [String] :requester Fetch item by given requester
-    # @option opts [Integer] :limit How many items to return at one time (max 1000) (default to 20)
+    # @option opts [String] :approver Fetch requests by given approver username
+    # @option opts [Integer] :limit How many items to return at one time (max 1000) (default to 100)
     # @option opts [Integer] :offset Starting Offset (default to 0)
+    # @option opts [Object] :filter Filter for querying collections.
     # @return [RequestOutCollection]
     def list_requests(opts = {})
       data, _status_code, _headers = list_requests_with_http_info(opts)
@@ -97,28 +96,21 @@ module ApprovalApiClient
     # Return an array of approval requests
     # Return an array of requests
     # @param [Hash] opts the optional parameters
-    # @option opts [Array<String>] :decision Fetch item by given decision (undecided, approved, denied)
-    # @option opts [Array<String>] :state Fetch item by given state (pending, skipped, notified, finished)
-    # @option opts [String] :requester Fetch item by given requester
+    # @option opts [String] :approver Fetch requests by given approver username
     # @option opts [Integer] :limit How many items to return at one time (max 1000)
     # @option opts [Integer] :offset Starting Offset
+    # @option opts [Object] :filter Filter for querying collections.
     # @return [Array<(RequestOutCollection, Fixnum, Hash)>] RequestOutCollection data, response status code and response headers
     def list_requests_with_http_info(opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: RequestApi.list_requests ...'
       end
-      if @api_client.config.client_side_validation && opts[:'decision'] && !opts[:'decision'].all? { |item| ['undecided', 'approved', 'denied'].include?(item) }
-        fail ArgumentError, 'invalid value for "decision", must include one of undecided, approved, denied'
-      end
-      if @api_client.config.client_side_validation && opts[:'state'] && !opts[:'state'].all? { |item| ['pending', 'skipped', 'notified', 'finished'].include?(item) }
-        fail ArgumentError, 'invalid value for "state", must include one of pending, skipped, notified, finished'
-      end
-      if @api_client.config.client_side_validation && !opts[:'limit'].nil? && opts[:'limit'] > 100
-        fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling RequestApi.list_requests, must be smaller than or equal to 100.'
+      if @api_client.config.client_side_validation && !opts[:'limit'].nil? && opts[:'limit'] > 1000
+        fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling RequestApi.list_requests, must be smaller than or equal to 1000.'
       end
 
-      if @api_client.config.client_side_validation && !opts[:'limit'].nil? && opts[:'limit'] < 20
-        fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling RequestApi.list_requests, must be greater than or equal to 20.'
+      if @api_client.config.client_side_validation && !opts[:'limit'].nil? && opts[:'limit'] < 1
+        fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling RequestApi.list_requests, must be greater than or equal to 1.'
       end
 
       if @api_client.config.client_side_validation && !opts[:'offset'].nil? && opts[:'offset'] < 0
@@ -130,11 +122,10 @@ module ApprovalApiClient
 
       # query parameters
       query_params = {}
-      query_params[:'decision'] = @api_client.build_collection_param(opts[:'decision'], :multi) if !opts[:'decision'].nil?
-      query_params[:'state'] = @api_client.build_collection_param(opts[:'state'], :multi) if !opts[:'state'].nil?
-      query_params[:'requester'] = opts[:'requester'] if !opts[:'requester'].nil?
+      query_params[:'approver'] = opts[:'approver'] if !opts[:'approver'].nil?
       query_params[:'limit'] = opts[:'limit'] if !opts[:'limit'].nil?
       query_params[:'offset'] = opts[:'offset'] if !opts[:'offset'].nil?
+      query_params[:'filter'] = opts[:'filter'] if !opts[:'filter'].nil?
 
       # header parameters
       header_params = {}
@@ -164,8 +155,9 @@ module ApprovalApiClient
     # Return approval requests by given workflow id
     # @param workflow_id Id of workflow
     # @param [Hash] opts the optional parameters
-    # @option opts [Integer] :limit How many items to return at one time (max 1000) (default to 20)
+    # @option opts [Integer] :limit How many items to return at one time (max 1000) (default to 100)
     # @option opts [Integer] :offset Starting Offset (default to 0)
+    # @option opts [Object] :filter Filter for querying collections.
     # @return [RequestOutCollection]
     def list_requests_by_workflow(workflow_id, opts = {})
       data, _status_code, _headers = list_requests_by_workflow_with_http_info(workflow_id, opts)
@@ -178,6 +170,7 @@ module ApprovalApiClient
     # @param [Hash] opts the optional parameters
     # @option opts [Integer] :limit How many items to return at one time (max 1000)
     # @option opts [Integer] :offset Starting Offset
+    # @option opts [Object] :filter Filter for querying collections.
     # @return [Array<(RequestOutCollection, Fixnum, Hash)>] RequestOutCollection data, response status code and response headers
     def list_requests_by_workflow_with_http_info(workflow_id, opts = {})
       if @api_client.config.debugging
@@ -187,12 +180,12 @@ module ApprovalApiClient
       if @api_client.config.client_side_validation && workflow_id.nil?
         fail ArgumentError, "Missing the required parameter 'workflow_id' when calling RequestApi.list_requests_by_workflow"
       end
-      if @api_client.config.client_side_validation && !opts[:'limit'].nil? && opts[:'limit'] > 100
-        fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling RequestApi.list_requests_by_workflow, must be smaller than or equal to 100.'
+      if @api_client.config.client_side_validation && !opts[:'limit'].nil? && opts[:'limit'] > 1000
+        fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling RequestApi.list_requests_by_workflow, must be smaller than or equal to 1000.'
       end
 
-      if @api_client.config.client_side_validation && !opts[:'limit'].nil? && opts[:'limit'] < 20
-        fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling RequestApi.list_requests_by_workflow, must be greater than or equal to 20.'
+      if @api_client.config.client_side_validation && !opts[:'limit'].nil? && opts[:'limit'] < 1
+        fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling RequestApi.list_requests_by_workflow, must be greater than or equal to 1.'
       end
 
       if @api_client.config.client_side_validation && !opts[:'offset'].nil? && opts[:'offset'] < 0
@@ -206,6 +199,7 @@ module ApprovalApiClient
       query_params = {}
       query_params[:'limit'] = opts[:'limit'] if !opts[:'limit'].nil?
       query_params[:'offset'] = opts[:'offset'] if !opts[:'offset'].nil?
+      query_params[:'filter'] = opts[:'filter'] if !opts[:'filter'].nil?
 
       # header parameters
       header_params = {}

--- a/lib/approval-api-client-ruby/api/template_api.rb
+++ b/lib/approval-api-client-ruby/api/template_api.rb
@@ -22,8 +22,9 @@ module ApprovalApiClient
     # Return all templates
     # Return all templates
     # @param [Hash] opts the optional parameters
-    # @option opts [Integer] :limit How many items to return at one time (max 1000) (default to 20)
+    # @option opts [Integer] :limit How many items to return at one time (max 1000) (default to 100)
     # @option opts [Integer] :offset Starting Offset (default to 0)
+    # @option opts [Object] :filter Filter for querying collections.
     # @return [TemplateOutCollection]
     def list_templates(opts = {})
       data, _status_code, _headers = list_templates_with_http_info(opts)
@@ -35,17 +36,18 @@ module ApprovalApiClient
     # @param [Hash] opts the optional parameters
     # @option opts [Integer] :limit How many items to return at one time (max 1000)
     # @option opts [Integer] :offset Starting Offset
+    # @option opts [Object] :filter Filter for querying collections.
     # @return [Array<(TemplateOutCollection, Fixnum, Hash)>] TemplateOutCollection data, response status code and response headers
     def list_templates_with_http_info(opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: TemplateApi.list_templates ...'
       end
-      if @api_client.config.client_side_validation && !opts[:'limit'].nil? && opts[:'limit'] > 100
-        fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling TemplateApi.list_templates, must be smaller than or equal to 100.'
+      if @api_client.config.client_side_validation && !opts[:'limit'].nil? && opts[:'limit'] > 1000
+        fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling TemplateApi.list_templates, must be smaller than or equal to 1000.'
       end
 
-      if @api_client.config.client_side_validation && !opts[:'limit'].nil? && opts[:'limit'] < 20
-        fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling TemplateApi.list_templates, must be greater than or equal to 20.'
+      if @api_client.config.client_side_validation && !opts[:'limit'].nil? && opts[:'limit'] < 1
+        fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling TemplateApi.list_templates, must be greater than or equal to 1.'
       end
 
       if @api_client.config.client_side_validation && !opts[:'offset'].nil? && opts[:'offset'] < 0
@@ -59,6 +61,7 @@ module ApprovalApiClient
       query_params = {}
       query_params[:'limit'] = opts[:'limit'] if !opts[:'limit'].nil?
       query_params[:'offset'] = opts[:'offset'] if !opts[:'offset'].nil?
+      query_params[:'filter'] = opts[:'filter'] if !opts[:'filter'].nil?
 
       # header parameters
       header_params = {}

--- a/lib/approval-api-client-ruby/api/workflow_api.rb
+++ b/lib/approval-api-client-ruby/api/workflow_api.rb
@@ -133,8 +133,9 @@ module ApprovalApiClient
     # Return all approval workflows
     # Return all approval workflows
     # @param [Hash] opts the optional parameters
-    # @option opts [Integer] :limit How many items to return at one time (max 1000) (default to 20)
+    # @option opts [Integer] :limit How many items to return at one time (max 1000) (default to 100)
     # @option opts [Integer] :offset Starting Offset (default to 0)
+    # @option opts [Object] :filter Filter for querying collections.
     # @return [WorkflowOutCollection]
     def list_workflows(opts = {})
       data, _status_code, _headers = list_workflows_with_http_info(opts)
@@ -146,17 +147,18 @@ module ApprovalApiClient
     # @param [Hash] opts the optional parameters
     # @option opts [Integer] :limit How many items to return at one time (max 1000)
     # @option opts [Integer] :offset Starting Offset
+    # @option opts [Object] :filter Filter for querying collections.
     # @return [Array<(WorkflowOutCollection, Fixnum, Hash)>] WorkflowOutCollection data, response status code and response headers
     def list_workflows_with_http_info(opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: WorkflowApi.list_workflows ...'
       end
-      if @api_client.config.client_side_validation && !opts[:'limit'].nil? && opts[:'limit'] > 100
-        fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling WorkflowApi.list_workflows, must be smaller than or equal to 100.'
+      if @api_client.config.client_side_validation && !opts[:'limit'].nil? && opts[:'limit'] > 1000
+        fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling WorkflowApi.list_workflows, must be smaller than or equal to 1000.'
       end
 
-      if @api_client.config.client_side_validation && !opts[:'limit'].nil? && opts[:'limit'] < 20
-        fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling WorkflowApi.list_workflows, must be greater than or equal to 20.'
+      if @api_client.config.client_side_validation && !opts[:'limit'].nil? && opts[:'limit'] < 1
+        fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling WorkflowApi.list_workflows, must be greater than or equal to 1.'
       end
 
       if @api_client.config.client_side_validation && !opts[:'offset'].nil? && opts[:'offset'] < 0
@@ -170,6 +172,7 @@ module ApprovalApiClient
       query_params = {}
       query_params[:'limit'] = opts[:'limit'] if !opts[:'limit'].nil?
       query_params[:'offset'] = opts[:'offset'] if !opts[:'offset'].nil?
+      query_params[:'filter'] = opts[:'filter'] if !opts[:'filter'].nil?
 
       # header parameters
       header_params = {}
@@ -199,8 +202,9 @@ module ApprovalApiClient
     # Return an array of workflows by given template id
     # @param template_id Id of template
     # @param [Hash] opts the optional parameters
-    # @option opts [Integer] :limit How many items to return at one time (max 1000) (default to 20)
+    # @option opts [Integer] :limit How many items to return at one time (max 1000) (default to 100)
     # @option opts [Integer] :offset Starting Offset (default to 0)
+    # @option opts [Object] :filter Filter for querying collections.
     # @return [WorkflowOutCollection]
     def list_workflows_by_template(template_id, opts = {})
       data, _status_code, _headers = list_workflows_by_template_with_http_info(template_id, opts)
@@ -213,6 +217,7 @@ module ApprovalApiClient
     # @param [Hash] opts the optional parameters
     # @option opts [Integer] :limit How many items to return at one time (max 1000)
     # @option opts [Integer] :offset Starting Offset
+    # @option opts [Object] :filter Filter for querying collections.
     # @return [Array<(WorkflowOutCollection, Fixnum, Hash)>] WorkflowOutCollection data, response status code and response headers
     def list_workflows_by_template_with_http_info(template_id, opts = {})
       if @api_client.config.debugging
@@ -222,12 +227,12 @@ module ApprovalApiClient
       if @api_client.config.client_side_validation && template_id.nil?
         fail ArgumentError, "Missing the required parameter 'template_id' when calling WorkflowApi.list_workflows_by_template"
       end
-      if @api_client.config.client_side_validation && !opts[:'limit'].nil? && opts[:'limit'] > 100
-        fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling WorkflowApi.list_workflows_by_template, must be smaller than or equal to 100.'
+      if @api_client.config.client_side_validation && !opts[:'limit'].nil? && opts[:'limit'] > 1000
+        fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling WorkflowApi.list_workflows_by_template, must be smaller than or equal to 1000.'
       end
 
-      if @api_client.config.client_side_validation && !opts[:'limit'].nil? && opts[:'limit'] < 20
-        fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling WorkflowApi.list_workflows_by_template, must be greater than or equal to 20.'
+      if @api_client.config.client_side_validation && !opts[:'limit'].nil? && opts[:'limit'] < 1
+        fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling WorkflowApi.list_workflows_by_template, must be greater than or equal to 1.'
       end
 
       if @api_client.config.client_side_validation && !opts[:'offset'].nil? && opts[:'offset'] < 0
@@ -241,6 +246,7 @@ module ApprovalApiClient
       query_params = {}
       query_params[:'limit'] = opts[:'limit'] if !opts[:'limit'].nil?
       query_params[:'offset'] = opts[:'offset'] if !opts[:'offset'].nil?
+      query_params[:'filter'] = opts[:'filter'] if !opts[:'filter'].nil?
 
       # header parameters
       header_params = {}

--- a/lib/approval-api-client-ruby/configuration.rb
+++ b/lib/approval-api-client-ruby/configuration.rb
@@ -128,9 +128,9 @@ module ApprovalApiClient
     attr_accessor :force_ending_format
 
     def initialize
-      @scheme = 'http'
-      @host = 'localhost'
-      @base_path = '/api/approval/v1.0'
+      @scheme = 'https'
+      @host = 'cloud.redhat.com'
+      @base_path = '//api/approval/v1.0'
       @api_key = {}
       @api_key_prefix = {}
       @timeout = 0
@@ -210,8 +210,28 @@ module ApprovalApiClient
     def server_settings
       [
         {
-          url: "http://localhost/api/approval/v1.0",
-          description: "No descriptoin provided",
+          url: "https://cloud.redhat.com/{basePath}",
+          description: "Production Server",
+          variables: {
+            basePath: {
+                description: "No descriptoin provided",
+                default_value: "/api/approval/v1.0",
+              }
+            }
+        },
+        {
+          url: "http://localhost:{port}/{basePath}",
+          description: "Development Server",
+          variables: {
+            port: {
+                description: "No descriptoin provided",
+                default_value: "3000",
+              },
+            basePath: {
+                description: "No descriptoin provided",
+                default_value: "/api/approval/v1.0",
+              }
+            }
         }
       ]
     end

--- a/lib/approval-api-client-ruby/models/action_in.rb
+++ b/lib/approval-api-client-ruby/models/action_in.rb
@@ -18,7 +18,7 @@ module ApprovalApiClient
     # The person who performs the action
     attr_accessor :processed_by
 
-    # Types of action, may be one of the value (approve, deny, notify, memo, or skip). The stage will be updated according to the operation.
+    # Types of action, may be one of the value (approve, cancel, deny, notify, memo, or skip). The stage will be updated according to the operation.
     attr_accessor :operation
 
     # Comments for action
@@ -102,7 +102,7 @@ module ApprovalApiClient
     # @return true if the model is valid
     def valid?
       return false if @operation.nil?
-      operation_validator = EnumAttributeValidator.new('String', ['approve', 'deny', 'notify', 'memo', 'skip'])
+      operation_validator = EnumAttributeValidator.new('String', ['approve', 'cancel', 'deny', 'notify', 'memo', 'skip'])
       return false unless operation_validator.valid?(@operation)
       true
     end
@@ -110,7 +110,7 @@ module ApprovalApiClient
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] operation Object to be assigned
     def operation=(operation)
-      validator = EnumAttributeValidator.new('String', ['approve', 'deny', 'notify', 'memo', 'skip'])
+      validator = EnumAttributeValidator.new('String', ['approve', 'cancel', 'deny', 'notify', 'memo', 'skip'])
       unless validator.valid?(operation)
         fail ArgumentError, 'invalid value for "operation", must be one of #{validator.allowable_values}.'
       end

--- a/lib/approval-api-client-ruby/models/action_out.rb
+++ b/lib/approval-api-client-ruby/models/action_out.rb
@@ -14,15 +14,6 @@ require 'date'
 
 module ApprovalApiClient
   class ActionOut
-    # The person who performs the action
-    attr_accessor :processed_by
-
-    # Types of action, may be one of the value (approve, deny, notify, memo, or skip). The stage will be updated according to the operation.
-    attr_accessor :operation
-
-    # Comments for action
-    attr_accessor :comments
-
     attr_accessor :id
 
     # Timestamp of creation
@@ -30,6 +21,15 @@ module ApprovalApiClient
 
     # Associated stage id
     attr_accessor :stage_id
+
+    # The person who performs the action
+    attr_accessor :processed_by
+
+    # Types of action, may be one of the value (approve, cancel, deny, notify, memo, or skip). The stage will be updated according to the operation.
+    attr_accessor :operation
+
+    # Comments for action
+    attr_accessor :comments
 
     class EnumAttributeValidator
       attr_reader :datatype
@@ -56,24 +56,24 @@ module ApprovalApiClient
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
-        :'processed_by' => :'processed_by',
-        :'operation' => :'operation',
-        :'comments' => :'comments',
         :'id' => :'id',
         :'created_at' => :'created_at',
-        :'stage_id' => :'stage_id'
+        :'stage_id' => :'stage_id',
+        :'processed_by' => :'processed_by',
+        :'operation' => :'operation',
+        :'comments' => :'comments'
       }
     end
 
     # Attribute type mapping.
     def self.openapi_types
       {
-        :'processed_by' => :'String',
-        :'operation' => :'String',
-        :'comments' => :'String',
         :'id' => :'String',
         :'created_at' => :'DateTime',
-        :'stage_id' => :'String'
+        :'stage_id' => :'String',
+        :'processed_by' => :'String',
+        :'operation' => :'String',
+        :'comments' => :'String'
       }
     end
 
@@ -84,6 +84,18 @@ module ApprovalApiClient
 
       # convert string to symbol for hash key
       attributes = attributes.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
+
+      if attributes.has_key?(:'id')
+        self.id = attributes[:'id']
+      end
+
+      if attributes.has_key?(:'created_at')
+        self.created_at = attributes[:'created_at']
+      end
+
+      if attributes.has_key?(:'stage_id')
+        self.stage_id = attributes[:'stage_id']
+      end
 
       if attributes.has_key?(:'processed_by')
         self.processed_by = attributes[:'processed_by']
@@ -98,28 +110,12 @@ module ApprovalApiClient
       if attributes.has_key?(:'comments')
         self.comments = attributes[:'comments']
       end
-
-      if attributes.has_key?(:'id')
-        self.id = attributes[:'id']
-      end
-
-      if attributes.has_key?(:'created_at')
-        self.created_at = attributes[:'created_at']
-      end
-
-      if attributes.has_key?(:'stage_id')
-        self.stage_id = attributes[:'stage_id']
-      end
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       invalid_properties = Array.new
-      if @operation.nil?
-        invalid_properties.push('invalid value for "operation", operation cannot be nil.')
-      end
-
       if @id.nil?
         invalid_properties.push('invalid value for "id", id cannot be nil.')
       end
@@ -134,18 +130,17 @@ module ApprovalApiClient
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
-      return false if @operation.nil?
-      operation_validator = EnumAttributeValidator.new('String', ['approve', 'deny', 'notify', 'memo', 'skip'])
-      return false unless operation_validator.valid?(@operation)
       return false if @id.nil?
       return false if @stage_id.nil?
+      operation_validator = EnumAttributeValidator.new('String', ['approve', 'cancel', 'deny', 'notify', 'memo', 'skip'])
+      return false unless operation_validator.valid?(@operation)
       true
     end
 
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] operation Object to be assigned
     def operation=(operation)
-      validator = EnumAttributeValidator.new('String', ['approve', 'deny', 'notify', 'memo', 'skip'])
+      validator = EnumAttributeValidator.new('String', ['approve', 'cancel', 'deny', 'notify', 'memo', 'skip'])
       unless validator.valid?(operation)
         fail ArgumentError, 'invalid value for "operation", must be one of #{validator.allowable_values}.'
       end
@@ -157,12 +152,12 @@ module ApprovalApiClient
     def ==(o)
       return true if self.equal?(o)
       self.class == o.class &&
-          processed_by == o.processed_by &&
-          operation == o.operation &&
-          comments == o.comments &&
           id == o.id &&
           created_at == o.created_at &&
-          stage_id == o.stage_id
+          stage_id == o.stage_id &&
+          processed_by == o.processed_by &&
+          operation == o.operation &&
+          comments == o.comments
     end
 
     # @see the `==` method
@@ -174,7 +169,7 @@ module ApprovalApiClient
     # Calculates hash code according to all attributes.
     # @return [Fixnum] Hash code
     def hash
-      [processed_by, operation, comments, id, created_at, stage_id].hash
+      [id, created_at, stage_id, processed_by, operation, comments].hash
     end
 
     # Builds the object from hash

--- a/lib/approval-api-client-ruby/models/request_out.rb
+++ b/lib/approval-api-client-ruby/models/request_out.rb
@@ -15,6 +15,32 @@ require 'date'
 module ApprovalApiClient
   # Approval request. Each request will associate with a workflow. Corresponding to the groups of the associated workflow, every request will have a list of stages to record the request processing details.
   class RequestOut
+    attr_accessor :id
+
+    # The state of stage or request. It may be one of values (canceled, pending, skipped, notified or finished)
+    attr_accessor :state
+
+    # Final decision, may be one of the value (undecided, approved, canceled or denied)
+    attr_accessor :decision
+
+    # Comments for requests
+    attr_accessor :reason
+
+    # Associate workflow id
+    attr_accessor :workflow_id
+
+    # Timestamp of creation
+    attr_accessor :created_at
+
+    # Timestamp of last update
+    attr_accessor :updated_at
+
+    # Current (or last) active stage. For regular approver this number is always 0
+    attr_accessor :active_stage
+
+    # Total number of stages. For regular approver this number is always 0.
+    attr_accessor :total_stages
+
     # Requester id
     attr_accessor :requester
 
@@ -26,20 +52,6 @@ module ApprovalApiClient
 
     # JSON object with request content
     attr_accessor :content
-
-    attr_accessor :id
-
-    # The state of stage or request. It may be one of values (pending, skipped, notified or finished)
-    attr_accessor :state
-
-    # Final decision, may be one of the value (undecided, approved, or denied)
-    attr_accessor :decision
-
-    # Comments for requests
-    attr_accessor :reason
-
-    # Associate workflow id
-    attr_accessor :workflow_id
 
     class EnumAttributeValidator
       attr_reader :datatype
@@ -66,30 +78,38 @@ module ApprovalApiClient
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
-        :'requester' => :'requester',
-        :'name' => :'name',
-        :'description' => :'description',
-        :'content' => :'content',
         :'id' => :'id',
         :'state' => :'state',
         :'decision' => :'decision',
         :'reason' => :'reason',
-        :'workflow_id' => :'workflow_id'
+        :'workflow_id' => :'workflow_id',
+        :'created_at' => :'created_at',
+        :'updated_at' => :'updated_at',
+        :'active_stage' => :'active_stage',
+        :'total_stages' => :'total_stages',
+        :'requester' => :'requester',
+        :'name' => :'name',
+        :'description' => :'description',
+        :'content' => :'content'
       }
     end
 
     # Attribute type mapping.
     def self.openapi_types
       {
-        :'requester' => :'String',
-        :'name' => :'String',
-        :'description' => :'String',
-        :'content' => :'Object',
         :'id' => :'String',
         :'state' => :'String',
         :'decision' => :'String',
         :'reason' => :'String',
-        :'workflow_id' => :'String'
+        :'workflow_id' => :'String',
+        :'created_at' => :'DateTime',
+        :'updated_at' => :'DateTime',
+        :'active_stage' => :'Integer',
+        :'total_stages' => :'Integer',
+        :'requester' => :'String',
+        :'name' => :'String',
+        :'description' => :'String',
+        :'content' => :'Object'
       }
     end
 
@@ -100,22 +120,6 @@ module ApprovalApiClient
 
       # convert string to symbol for hash key
       attributes = attributes.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
-
-      if attributes.has_key?(:'requester')
-        self.requester = attributes[:'requester']
-      end
-
-      if attributes.has_key?(:'name')
-        self.name = attributes[:'name']
-      end
-
-      if attributes.has_key?(:'description')
-        self.description = attributes[:'description']
-      end
-
-      if attributes.has_key?(:'content')
-        self.content = attributes[:'content']
-      end
 
       if attributes.has_key?(:'id')
         self.id = attributes[:'id']
@@ -140,31 +144,53 @@ module ApprovalApiClient
       if attributes.has_key?(:'workflow_id')
         self.workflow_id = attributes[:'workflow_id']
       end
+
+      if attributes.has_key?(:'created_at')
+        self.created_at = attributes[:'created_at']
+      end
+
+      if attributes.has_key?(:'updated_at')
+        self.updated_at = attributes[:'updated_at']
+      end
+
+      if attributes.has_key?(:'active_stage')
+        self.active_stage = attributes[:'active_stage']
+      end
+
+      if attributes.has_key?(:'total_stages')
+        self.total_stages = attributes[:'total_stages']
+      end
+
+      if attributes.has_key?(:'requester')
+        self.requester = attributes[:'requester']
+      end
+
+      if attributes.has_key?(:'name')
+        self.name = attributes[:'name']
+      end
+
+      if attributes.has_key?(:'description')
+        self.description = attributes[:'description']
+      end
+
+      if attributes.has_key?(:'content')
+        self.content = attributes[:'content']
+      end
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       invalid_properties = Array.new
-      if @name.nil?
-        invalid_properties.push('invalid value for "name", name cannot be nil.')
-      end
-
-      if @content.nil?
-        invalid_properties.push('invalid value for "content", content cannot be nil.')
-      end
-
       invalid_properties
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
-      return false if @name.nil?
-      return false if @content.nil?
-      state_validator = EnumAttributeValidator.new('String', ['pending', 'skipped', 'notified', 'finished'])
+      state_validator = EnumAttributeValidator.new('String', ['canceled', 'pending', 'skipped', 'notified', 'finished'])
       return false unless state_validator.valid?(@state)
-      decision_validator = EnumAttributeValidator.new('String', ['undecided', 'approved', 'denied'])
+      decision_validator = EnumAttributeValidator.new('String', ['undecided', 'approved', 'canceled', 'denied'])
       return false unless decision_validator.valid?(@decision)
       true
     end
@@ -172,7 +198,7 @@ module ApprovalApiClient
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] state Object to be assigned
     def state=(state)
-      validator = EnumAttributeValidator.new('String', ['pending', 'skipped', 'notified', 'finished'])
+      validator = EnumAttributeValidator.new('String', ['canceled', 'pending', 'skipped', 'notified', 'finished'])
       unless validator.valid?(state)
         fail ArgumentError, 'invalid value for "state", must be one of #{validator.allowable_values}.'
       end
@@ -182,7 +208,7 @@ module ApprovalApiClient
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] decision Object to be assigned
     def decision=(decision)
-      validator = EnumAttributeValidator.new('String', ['undecided', 'approved', 'denied'])
+      validator = EnumAttributeValidator.new('String', ['undecided', 'approved', 'canceled', 'denied'])
       unless validator.valid?(decision)
         fail ArgumentError, 'invalid value for "decision", must be one of #{validator.allowable_values}.'
       end
@@ -194,15 +220,19 @@ module ApprovalApiClient
     def ==(o)
       return true if self.equal?(o)
       self.class == o.class &&
-          requester == o.requester &&
-          name == o.name &&
-          description == o.description &&
-          content == o.content &&
           id == o.id &&
           state == o.state &&
           decision == o.decision &&
           reason == o.reason &&
-          workflow_id == o.workflow_id
+          workflow_id == o.workflow_id &&
+          created_at == o.created_at &&
+          updated_at == o.updated_at &&
+          active_stage == o.active_stage &&
+          total_stages == o.total_stages &&
+          requester == o.requester &&
+          name == o.name &&
+          description == o.description &&
+          content == o.content
     end
 
     # @see the `==` method
@@ -214,7 +244,7 @@ module ApprovalApiClient
     # Calculates hash code according to all attributes.
     # @return [Fixnum] Hash code
     def hash
-      [requester, name, description, content, id, state, decision, reason, workflow_id].hash
+      [id, state, decision, reason, workflow_id, created_at, updated_at, active_stage, total_stages, requester, name, description, content].hash
     end
 
     # Builds the object from hash

--- a/lib/approval-api-client-ruby/models/stage_out.rb
+++ b/lib/approval-api-client-ruby/models/stage_out.rb
@@ -23,10 +23,10 @@ module ApprovalApiClient
     # Associated group reference id
     attr_accessor :group_ref
 
-    # The state of stage or request. It may be one of values (pending, skipped, notified or finished)
+    # The state of stage or request. It may be one of values (canceled, pending, skipped, notified or finished)
     attr_accessor :state
 
-    # Final decision, may be one of the value (undecided, approved, or denied)
+    # Final decision, may be one of the value (undecided, approved, canceled or denied)
     attr_accessor :decision
 
     # the time approvers in the stage are notified
@@ -125,9 +125,9 @@ module ApprovalApiClient
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
-      state_validator = EnumAttributeValidator.new('String', ['pending', 'skipped', 'notified', 'finished'])
+      state_validator = EnumAttributeValidator.new('String', ['canceled', 'pending', 'skipped', 'notified', 'finished'])
       return false unless state_validator.valid?(@state)
-      decision_validator = EnumAttributeValidator.new('String', ['undecided', 'approved', 'denied'])
+      decision_validator = EnumAttributeValidator.new('String', ['undecided', 'approved', 'canceled', 'denied'])
       return false unless decision_validator.valid?(@decision)
       true
     end
@@ -135,7 +135,7 @@ module ApprovalApiClient
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] state Object to be assigned
     def state=(state)
-      validator = EnumAttributeValidator.new('String', ['pending', 'skipped', 'notified', 'finished'])
+      validator = EnumAttributeValidator.new('String', ['canceled', 'pending', 'skipped', 'notified', 'finished'])
       unless validator.valid?(state)
         fail ArgumentError, 'invalid value for "state", must be one of #{validator.allowable_values}.'
       end
@@ -145,7 +145,7 @@ module ApprovalApiClient
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] decision Object to be assigned
     def decision=(decision)
-      validator = EnumAttributeValidator.new('String', ['undecided', 'approved', 'denied'])
+      validator = EnumAttributeValidator.new('String', ['undecided', 'approved', 'canceled', 'denied'])
       unless validator.valid?(decision)
         fail ArgumentError, 'invalid value for "decision", must be one of #{validator.allowable_values}.'
       end

--- a/lib/approval-api-client-ruby/models/workflow_out.rb
+++ b/lib/approval-api-client-ruby/models/workflow_out.rb
@@ -15,6 +15,11 @@ require 'date'
 module ApprovalApiClient
   # The workflow to process approval requests. Each workflow is linked to multiple groups of approvals.
   class WorkflowOut
+    attr_accessor :id
+
+    # Associated template id
+    attr_accessor :template_id
+
     attr_accessor :name
 
     attr_accessor :description
@@ -22,30 +27,25 @@ module ApprovalApiClient
     # Group reference ids associated with workflow
     attr_accessor :group_refs
 
-    attr_accessor :id
-
-    # Associated template id
-    attr_accessor :template_id
-
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
+        :'id' => :'id',
+        :'template_id' => :'template_id',
         :'name' => :'name',
         :'description' => :'description',
-        :'group_refs' => :'group_refs',
-        :'id' => :'id',
-        :'template_id' => :'template_id'
+        :'group_refs' => :'group_refs'
       }
     end
 
     # Attribute type mapping.
     def self.openapi_types
       {
+        :'id' => :'String',
+        :'template_id' => :'String',
         :'name' => :'String',
         :'description' => :'String',
-        :'group_refs' => :'Array<String>',
-        :'id' => :'String',
-        :'template_id' => :'String'
+        :'group_refs' => :'Array<String>'
       }
     end
 
@@ -56,6 +56,14 @@ module ApprovalApiClient
 
       # convert string to symbol for hash key
       attributes = attributes.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
+
+      if attributes.has_key?(:'id')
+        self.id = attributes[:'id']
+      end
+
+      if attributes.has_key?(:'template_id')
+        self.template_id = attributes[:'template_id']
+      end
 
       if attributes.has_key?(:'name')
         self.name = attributes[:'name']
@@ -70,36 +78,18 @@ module ApprovalApiClient
           self.group_refs = value
         end
       end
-
-      if attributes.has_key?(:'id')
-        self.id = attributes[:'id']
-      end
-
-      if attributes.has_key?(:'template_id')
-        self.template_id = attributes[:'template_id']
-      end
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       invalid_properties = Array.new
-      if @name.nil?
-        invalid_properties.push('invalid value for "name", name cannot be nil.')
-      end
-
-      if @group_refs.nil?
-        invalid_properties.push('invalid value for "group_refs", group_refs cannot be nil.')
-      end
-
       invalid_properties
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
-      return false if @name.nil?
-      return false if @group_refs.nil?
       true
     end
 
@@ -108,11 +98,11 @@ module ApprovalApiClient
     def ==(o)
       return true if self.equal?(o)
       self.class == o.class &&
+          id == o.id &&
+          template_id == o.template_id &&
           name == o.name &&
           description == o.description &&
-          group_refs == o.group_refs &&
-          id == o.id &&
-          template_id == o.template_id
+          group_refs == o.group_refs
     end
 
     # @see the `==` method
@@ -124,7 +114,7 @@ module ApprovalApiClient
     # Calculates hash code according to all attributes.
     # @return [Fixnum] Hash code
     def hash
-      [name, description, group_refs, id, template_id].hash
+      [id, template_id, name, description, group_refs].hash
     end
 
     # Builds the object from hash

--- a/openapi.json
+++ b/openapi.json
@@ -188,19 +188,16 @@
                 "operationId": "listRequests",
                 "parameters": [
                     {
-                        "$ref": "#/components/parameters/decision"
-                    },
-                    {
-                        "$ref": "#/components/parameters/state"
-                    },
-                    {
-                        "$ref": "#/components/parameters/requester"
+                        "$ref": "#/components/parameters/approver"
                     },
                     {
                         "$ref": "#/components/parameters/limit"
                     },
                     {
                         "$ref": "#/components/parameters/offset"
+                    },
+                    {
+                        "$ref": "#/components/parameters/filter"
                     }
                 ],
                 "responses": {
@@ -257,6 +254,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/offset"
+                    },
+                    {
+                        "$ref": "#/components/parameters/filter"
                     }
                 ],
                 "responses": {
@@ -389,6 +389,59 @@
                 }
             }
         },
+        "/requests/{request_id}/actions": {
+            "post": {
+                "tags": [
+                  "Action"
+                ],
+                "summary": "Add an action to current active stage of a given request",
+                "description": "Add an action to current active stage of a given request. If request is finished, i.e. no current active stage is available, no action can be posted here.",
+                "operationId": "createActionByRequest",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/request_id"
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ActionIn"
+                            }
+                        }
+                    },
+                    "description": "Action object that will be added",
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ActionOut"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/400BadRequestResponse"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/401UnauthorizedResponse"
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/403ForbiddenResponse"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/404NotFoundResponse"
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/422UnprocessableEntityResponse"
+                    }
+                }
+            }
+        },
         "/requests/{request_id}/stages": {
             "get": {
                 "tags": [
@@ -487,6 +540,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/offset"
+                    },
+                    {
+                        "$ref": "#/components/parameters/filter"
                     }
                 ],
                 "responses": {
@@ -582,6 +638,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/offset"
+                    },
+                    {
+                        "$ref": "#/components/parameters/filter"
                     }
                 ],
                 "responses": {
@@ -638,6 +697,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/offset"
+                    },
+                    {
+                        "$ref": "#/components/parameters/filter"
                     }
                 ],
                 "responses": {
@@ -860,13 +922,27 @@
             "Basic_auth": []
         }
     ],
-    "externalDocs": {
-        "description": "Find out more about Swagger",
-        "url": "http://swagger.io"
-    },
     "servers": [
         {
-            "url": "http://localhost/api/approval/v1.0"
+            "url": "https://cloud.redhat.com/{basePath}",
+            "description": "Production Server",
+            "variables": {
+                "basePath": {
+                    "default": "/api/approval/v1.0"
+                }
+            }
+        },
+        {
+            "url": "http://localhost:{port}/{basePath}",
+            "description": "Development Server",
+            "variables": {
+                "port": {
+                    "default": "3000"
+                },
+                "basePath": {
+                    "default": "/api/approval/v1.0"
+                }
+            }
         }
     ],
     "components": {
@@ -877,7 +953,7 @@
                 "description": "Query by id",
                 "required": true,
                 "schema": {
-                    "type": "integer"
+                    "type": "string"
                 }
             },
             "template_id": {
@@ -886,7 +962,7 @@
                 "description": "Id of template",
                 "required": true,
                 "schema": {
-                    "type": "integer"
+                    "type": "string"
                 }
             },
             "workflow_id": {
@@ -895,7 +971,7 @@
                 "description": "Id of workflow",
                 "required": true,
                 "schema": {
-                    "type": "integer"
+                    "type": "string"
                 }
             },
             "request_id": {
@@ -904,7 +980,7 @@
                 "description": "Id of request",
                 "required": true,
                 "schema": {
-                    "type": "integer"
+                    "type": "string"
                 }
             },
             "stage_id": {
@@ -913,7 +989,7 @@
                 "description": "Id of stage",
                 "required": true,
                 "schema": {
-                    "type": "integer"
+                    "type": "string"
                 }
             },
             "limit": {
@@ -924,9 +1000,9 @@
                 "schema": {
                     "type": "integer",
                     "format": "int32",
-                    "minimum": 20,
-                    "maximum": 100,
-                    "default": 20
+                    "minimum": 1,
+                    "maximum": 1000,
+                    "default": 100
                 }
             },
             "offset": {
@@ -941,45 +1017,21 @@
                     "default": 0
                 }
             },
-            "state": {
-                "name": "state",
+            "filter": {
                 "in": "query",
-                "description": "Fetch item by given state (pending, skipped, notified, finished)",
+                "name": "filter",
+                "description": "Filter for querying collections.",
                 "required": false,
+                "style": "deepObject",
+                "explode": true,
                 "schema": {
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "enum": [
-                            "pending",
-                            "skipped",
-                            "notified",
-                            "finished"
-                        ]
-                    }
+                    "type": "object"
                 }
             },
-            "decision": {
-                "name": "decision",
+            "approver": {
+                "name": "approver",
                 "in": "query",
-                "description": "Fetch item by given decision (undecided, approved, denied)",
-                "required": false,
-                "schema": {
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "enum": [
-                            "undecided",
-                            "approved",
-                            "denied"
-                        ]
-                    }
-                }
-            },
-            "requester": {
-                "name": "requester",
-                "in": "query",
-                "description": "Fetch item by given requester",
+                "description": "Fetch requests by given approver username",
                 "required": false,
                 "schema": {
                     "type": "string"
@@ -1027,9 +1079,10 @@
                     },
                     "operation": {
                         "type": "string",
-                        "description": "Types of action, may be one of the value (approve, deny, notify, memo, or skip). The stage will be updated according to the operation.",
+                        "description": "Types of action, may be one of the value (approve, cancel, deny, notify, memo, or skip). The stage will be updated according to the operation.",
                         "enum": [
                             "approve",
+                            "cancel",
                             "deny",
                             "notify",
                             "memo",
@@ -1045,32 +1098,47 @@
                 }
             },
             "ActionOut": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/ActionIn"
+                "type": "object",
+                "required": [
+                    "id",
+                    "stage_id"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
                     },
-                    {
-                        "type": "object",
-                        "required": [
-                            "id",
-                            "stage_id"
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp of creation"
+                    },
+                    "stage_id": {
+                        "type": "string",
+                        "description": "Associated stage id"
+                    },
+                    "processed_by": {
+                        "type": "string",
+                        "description": "The person who performs the action"
+                    },
+                    "operation": {
+                        "type": "string",
+                        "description": "Types of action, may be one of the value (approve, cancel, deny, notify, memo, or skip). The stage will be updated according to the operation.",
+                        "enum": [
+                            "approve",
+                            "cancel",
+                            "deny",
+                            "notify",
+                            "memo",
+                            "skip"
                         ],
-                        "properties": {
-                            "id": {
-                                "type": "string"
-                            },
-                            "created_at": {
-                                "type": "string",
-                                "format": "date-time",
-                                "description": "Timestamp of creation"
-                            },
-                            "stage_id": {
-                                "type": "string",
-                                "description": "Associated stage id"
-                            }
-                        }
+                        "default": "memo"
+                    },
+                    "comments": {
+                        "type": "string",
+                        "description": "Comments for action",
+                        "readOnly": true
                     }
-                ]
+                }
             },
             "RequestIn": {
                 "type": "object",
@@ -1100,48 +1168,77 @@
             },
             "RequestOut": {
                 "description": "Approval request. Each request will associate with a workflow. Corresponding to the groups of the associated workflow, every request will have a list of stages to record the request processing details.",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/RequestIn"
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
                     },
-                    {
+                    "state": {
+                        "type": "string",
+                        "description": "The state of stage or request. It may be one of values (canceled, pending, skipped, notified or finished)",
+                        "enum": [
+                            "canceled",
+                            "pending",
+                            "skipped",
+                            "notified",
+                            "finished"
+                        ],
+                        "default": "pending"
+                    },
+                    "decision": {
+                        "type": "string",
+                        "description": "Final decision, may be one of the value (undecided, approved, canceled or denied)",
+                        "enum": [
+                            "undecided",
+                            "approved",
+                            "canceled",
+                            "denied"
+                        ],
+                        "default": "undecided"
+                    },
+                    "reason": {
+                        "type": "string",
+                        "description": "Comments for requests"
+                    },
+                    "workflow_id": {
+                        "type": "string",
+                        "description": "Associate workflow id"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp of creation"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp of last update"
+                    },
+                    "active_stage": {
+                        "type": "integer",
+                        "description": "Current (or last) active stage. For regular approver this number is always 0"
+                    },
+                    "total_stages": {
+                        "type": "integer",
+                        "description": "Total number of stages. For regular approver this number is always 0."
+                    },
+                    "requester": {
+                        "type": "string",
+                        "description": "Requester id"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Request name"
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Request description"
+                    },
+                    "content": {
                         "type": "object",
-                        "properties": {
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "description": "The state of stage or request. It may be one of values (pending, skipped, notified or finished)",
-                                "enum": [
-                                    "pending",
-                                    "skipped",
-                                    "notified",
-                                    "finished"
-                                ],
-                                "default": "pending"
-                            },
-                            "decision": {
-                                "type": "string",
-                                "description": "Final decision, may be one of the value (undecided, approved, or denied)",
-                                "enum": [
-                                    "undecided",
-                                    "approved",
-                                    "denied"
-                                ],
-                                "default": "undecided"
-                            },
-                            "reason": {
-                                "type": "string",
-                                "description": "Comments for requests"
-                            },
-                            "workflow_id": {
-                                "type": "string",
-                                "description": "Associate workflow id"
-                            }
-                        }
+                        "description": "JSON object with request content"
                     }
-                ]
+                }
             },
             "StageOut": {
                 "type": "object",
@@ -1160,8 +1257,9 @@
                     },
                     "state": {
                         "type": "string",
-                        "description": "The state of stage or request. It may be one of values (pending, skipped, notified or finished)",
+                        "description": "The state of stage or request. It may be one of values (canceled, pending, skipped, notified or finished)",
                         "enum": [
+                            "canceled",
                             "pending",
                             "skipped",
                             "notified",
@@ -1171,10 +1269,11 @@
                     },
                     "decision": {
                         "type": "string",
-                        "description": "Final decision, may be one of the value (undecided, approved, or denied)",
+                        "description": "Final decision, may be one of the value (undecided, approved, canceled or denied)",
                         "enum": [
                             "undecided",
                             "approved",
+                            "canceled",
                             "denied"
                         ],
                         "default": "undecided"
@@ -1224,23 +1323,29 @@
             },
             "WorkflowOut": {
                 "description": "The workflow to process approval requests. Each workflow is linked to multiple groups of approvals.",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/WorkflowIn"
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
                     },
-                    {
-                        "type": "object",
-                        "properties": {
-                            "id": {
-                                "type": "string"
-                            },
-                            "template_id": {
-                                "type": "string",
-                                "description": "Associated template id"
-                            }
+                    "template_id": {
+                        "type": "string",
+                        "description": "Associated template id"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "group_refs": {
+                        "type": "array",
+                        "description": "Group reference ids associated with workflow",
+                        "items": {
+                            "type": "string"
                         }
                     }
-                ]
+                }
             },
             "ActionOutCollection": {
                 "type": "object",

--- a/spec/api/action_api_spec.rb
+++ b/spec/api/action_api_spec.rb
@@ -45,6 +45,19 @@ describe 'ActionApi' do
     end
   end
 
+  # unit tests for create_action_by_request
+  # Add an action to current active stage of a given request
+  # Add an action to current active stage of a given request. If request is finished, i.e. no current active stage is available, no action can be posted here.
+  # @param request_id Id of request
+  # @param action_in Action object that will be added
+  # @param [Hash] opts the optional parameters
+  # @return [ActionOut]
+  describe 'create_action_by_request test' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
   # unit tests for list_actions_by_stage
   # Return actions in a given stage
   # List all actions of a stage

--- a/spec/api/request_api_spec.rb
+++ b/spec/api/request_api_spec.rb
@@ -49,11 +49,10 @@ describe 'RequestApi' do
   # Return an array of approval requests
   # Return an array of requests
   # @param [Hash] opts the optional parameters
-  # @option opts [Array<String>] :decision Fetch item by given decision (undecided, approved, denied)
-  # @option opts [Array<String>] :state Fetch item by given state (pending, skipped, notified, finished)
-  # @option opts [String] :requester Fetch item by given requester
+  # @option opts [String] :approver Fetch requests by given approver username
   # @option opts [Integer] :limit How many items to return at one time (max 1000)
   # @option opts [Integer] :offset Starting Offset
+  # @option opts [Object] :filter Filter for querying collections.
   # @return [RequestOutCollection]
   describe 'list_requests test' do
     it 'should work' do
@@ -68,6 +67,7 @@ describe 'RequestApi' do
   # @param [Hash] opts the optional parameters
   # @option opts [Integer] :limit How many items to return at one time (max 1000)
   # @option opts [Integer] :offset Starting Offset
+  # @option opts [Object] :filter Filter for querying collections.
   # @return [RequestOutCollection]
   describe 'list_requests_by_workflow test' do
     it 'should work' do

--- a/spec/api/template_api_spec.rb
+++ b/spec/api/template_api_spec.rb
@@ -38,6 +38,7 @@ describe 'TemplateApi' do
   # @param [Hash] opts the optional parameters
   # @option opts [Integer] :limit How many items to return at one time (max 1000)
   # @option opts [Integer] :offset Starting Offset
+  # @option opts [Object] :filter Filter for querying collections.
   # @return [TemplateOutCollection]
   describe 'list_templates test' do
     it 'should work' do

--- a/spec/api/workflow_api_spec.rb
+++ b/spec/api/workflow_api_spec.rb
@@ -63,6 +63,7 @@ describe 'WorkflowApi' do
   # @param [Hash] opts the optional parameters
   # @option opts [Integer] :limit How many items to return at one time (max 1000)
   # @option opts [Integer] :offset Starting Offset
+  # @option opts [Object] :filter Filter for querying collections.
   # @return [WorkflowOutCollection]
   describe 'list_workflows test' do
     it 'should work' do
@@ -77,6 +78,7 @@ describe 'WorkflowApi' do
   # @param [Hash] opts the optional parameters
   # @option opts [Integer] :limit How many items to return at one time (max 1000)
   # @option opts [Integer] :offset Starting Offset
+  # @option opts [Object] :filter Filter for querying collections.
   # @return [WorkflowOutCollection]
   describe 'list_workflows_by_template test' do
     it 'should work' do

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -18,7 +18,7 @@ describe ApprovalApiClient::Configuration do
   before(:each) do
     # uncomment below to setup host and base_path
     # require 'URI'
-    # uri = URI.parse("http://localhost/api/approval/v1.0")
+    # uri = URI.parse("https://cloud.redhat.com//api/approval/v1.0")
     # ApprovalApiClient.configure do |c|
     #   c.host = uri.host
     #   c.base_path = uri.path
@@ -28,14 +28,14 @@ describe ApprovalApiClient::Configuration do
   describe '#base_url' do
     it 'should have the default value' do
       # uncomment below to test default value of the base path
-      # expect(config.base_url).to eq("http://localhost/api/approval/v1.0")
+      # expect(config.base_url).to eq("https://cloud.redhat.com//api/approval/v1.0")
     end
 
     it 'should remove trailing slashes' do
       [nil, '', '/', '//'].each do |base_path|
         config.base_path = base_path
         # uncomment below to test trailing slashes
-        # expect(config.base_url).to eq("http://localhost/api/approval/v1.0")
+        # expect(config.base_url).to eq("https://cloud.redhat.com//api/approval/v1.0")
       end
     end
   end

--- a/spec/models/action_in_spec.rb
+++ b/spec/models/action_in_spec.rb
@@ -41,7 +41,7 @@ describe 'ActionIn' do
   describe 'test attribute "operation"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
-      # validator = Petstore::EnumTest::EnumAttributeValidator.new('String', ["approve", "deny", "notify", "memo", "skip"])
+      # validator = Petstore::EnumTest::EnumAttributeValidator.new('String', ["approve", "cancel", "deny", "notify", "memo", "skip"])
       # validator.allowable_values.each do |value|
       #   expect { @instance.operation = value }.not_to raise_error
       # end

--- a/spec/models/action_out_spec.rb
+++ b/spec/models/action_out_spec.rb
@@ -32,28 +32,6 @@ describe 'ActionOut' do
       expect(@instance).to be_instance_of(ApprovalApiClient::ActionOut)
     end
   end
-  describe 'test attribute "processed_by"' do
-    it 'should work' do
-      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
-    end
-  end
-
-  describe 'test attribute "operation"' do
-    it 'should work' do
-      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
-      # validator = Petstore::EnumTest::EnumAttributeValidator.new('String', ["approve", "deny", "notify", "memo", "skip"])
-      # validator.allowable_values.each do |value|
-      #   expect { @instance.operation = value }.not_to raise_error
-      # end
-    end
-  end
-
-  describe 'test attribute "comments"' do
-    it 'should work' do
-      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
-    end
-  end
-
   describe 'test attribute "id"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
@@ -67,6 +45,28 @@ describe 'ActionOut' do
   end
 
   describe 'test attribute "stage_id"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
+  describe 'test attribute "processed_by"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
+  describe 'test attribute "operation"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+      # validator = Petstore::EnumTest::EnumAttributeValidator.new('String', ["approve", "cancel", "deny", "notify", "memo", "skip"])
+      # validator.allowable_values.each do |value|
+      #   expect { @instance.operation = value }.not_to raise_error
+      # end
+    end
+  end
+
+  describe 'test attribute "comments"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
     end

--- a/spec/models/request_out_spec.rb
+++ b/spec/models/request_out_spec.rb
@@ -32,6 +32,68 @@ describe 'RequestOut' do
       expect(@instance).to be_instance_of(ApprovalApiClient::RequestOut)
     end
   end
+  describe 'test attribute "id"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
+  describe 'test attribute "state"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+      # validator = Petstore::EnumTest::EnumAttributeValidator.new('String', ["canceled", "pending", "skipped", "notified", "finished"])
+      # validator.allowable_values.each do |value|
+      #   expect { @instance.state = value }.not_to raise_error
+      # end
+    end
+  end
+
+  describe 'test attribute "decision"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+      # validator = Petstore::EnumTest::EnumAttributeValidator.new('String', ["undecided", "approved", "canceled", "denied"])
+      # validator.allowable_values.each do |value|
+      #   expect { @instance.decision = value }.not_to raise_error
+      # end
+    end
+  end
+
+  describe 'test attribute "reason"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
+  describe 'test attribute "workflow_id"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
+  describe 'test attribute "created_at"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
+  describe 'test attribute "updated_at"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
+  describe 'test attribute "active_stage"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
+  describe 'test attribute "total_stages"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
   describe 'test attribute "requester"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
@@ -51,44 +113,6 @@ describe 'RequestOut' do
   end
 
   describe 'test attribute "content"' do
-    it 'should work' do
-      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
-    end
-  end
-
-  describe 'test attribute "id"' do
-    it 'should work' do
-      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
-    end
-  end
-
-  describe 'test attribute "state"' do
-    it 'should work' do
-      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
-      # validator = Petstore::EnumTest::EnumAttributeValidator.new('String', ["pending", "skipped", "notified", "finished"])
-      # validator.allowable_values.each do |value|
-      #   expect { @instance.state = value }.not_to raise_error
-      # end
-    end
-  end
-
-  describe 'test attribute "decision"' do
-    it 'should work' do
-      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
-      # validator = Petstore::EnumTest::EnumAttributeValidator.new('String', ["undecided", "approved", "denied"])
-      # validator.allowable_values.each do |value|
-      #   expect { @instance.decision = value }.not_to raise_error
-      # end
-    end
-  end
-
-  describe 'test attribute "reason"' do
-    it 'should work' do
-      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
-    end
-  end
-
-  describe 'test attribute "workflow_id"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
     end

--- a/spec/models/stage_out_spec.rb
+++ b/spec/models/stage_out_spec.rb
@@ -53,7 +53,7 @@ describe 'StageOut' do
   describe 'test attribute "state"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
-      # validator = Petstore::EnumTest::EnumAttributeValidator.new('String', ["pending", "skipped", "notified", "finished"])
+      # validator = Petstore::EnumTest::EnumAttributeValidator.new('String', ["canceled", "pending", "skipped", "notified", "finished"])
       # validator.allowable_values.each do |value|
       #   expect { @instance.state = value }.not_to raise_error
       # end
@@ -63,7 +63,7 @@ describe 'StageOut' do
   describe 'test attribute "decision"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
-      # validator = Petstore::EnumTest::EnumAttributeValidator.new('String', ["undecided", "approved", "denied"])
+      # validator = Petstore::EnumTest::EnumAttributeValidator.new('String', ["undecided", "approved", "canceled", "denied"])
       # validator.allowable_values.each do |value|
       #   expect { @instance.decision = value }.not_to raise_error
       # end

--- a/spec/models/workflow_out_spec.rb
+++ b/spec/models/workflow_out_spec.rb
@@ -32,6 +32,18 @@ describe 'WorkflowOut' do
       expect(@instance).to be_instance_of(ApprovalApiClient::WorkflowOut)
     end
   end
+  describe 'test attribute "id"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
+  describe 'test attribute "template_id"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
   describe 'test attribute "name"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
@@ -45,18 +57,6 @@ describe 'WorkflowOut' do
   end
 
   describe 'test attribute "group_refs"' do
-    it 'should work' do
-      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
-    end
-  end
-
-  describe 'test attribute "id"' do
-    it 'should work' do
-      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
-    end
-  end
-
-  describe 'test attribute "template_id"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
     end


### PR DESCRIPTION
Just ran `./generate.sh` this morning (so should include all changes from 2019-06-20). Any changes that potentially get merged today will not be included in this PR.

There's really only one new route that this enables, which is the `create_action_by_request` route. All of the other changes seem to be attribute related.

@mkanoor or @hsong-rh Can you review and let me know if there's anything that I need to exclude? I simply ran `./generate.sh` so I'm not sure if it maybe pulled in stuff it shouldn't have. Thanks!
